### PR TITLE
Adding Webpage for All Data From Single Resort

### DIFF
--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -11,7 +11,6 @@ import collection.mutable.ArrayBuffer
 import collection.mutable.Map
 import scala.concurrent.Future
 import scala.concurrent._
-import scala.concurrent.duration.{SECONDS, Duration}
 import ExecutionContext.Implicits.global 
 import scrapers.ScraperFactory
 
@@ -32,7 +31,7 @@ class HomeController @Inject()(val controllerComponents: ControllerComponents, v
    */
   def index() = Action.async { implicit request: Request[AnyContent] =>
     resortData.getLatestSnapshotForAllResorts.map(
-      rvArray => rvArray.map(f => ResortSnapshotFactory.fromJson(f._1.asInstanceOf[String], ResortsFactory.fromString(f._2)))//ResortSnapshotFactory.fromJson(f(0).asInstanceOf[String], ta).asInstanceOf[ResortSnapshot]
+      rvArray => rvArray.map(f => ResortSnapshotFactory.resortSnapshotFromJson(f._1.asInstanceOf[String], ResortsFactory.fromString(f._2)))//ResortSnapshotFactory.fromJson(f(0).asInstanceOf[String], ta).asInstanceOf[ResortSnapshot]
     ).map(snapshotArray => Ok(views.html.index(snapshotArray)))
   }
 

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -1,9 +1,7 @@
 package controllers
 
 import javax.inject._
-import play.api._
 import play.api.mvc._
-import play.api.libs.ws._
 import dao.ResortData
 import models._
 import scrapers.ABasinScraper

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -31,8 +31,14 @@ class HomeController @Inject()(val controllerComponents: ControllerComponents, v
    */
   def index() = Action.async { implicit request: Request[AnyContent] =>
     resortData.getLatestSnapshotForAllResorts.map(
-      rvArray => rvArray.map(f => ResortSnapshotFactory.resortSnapshotFromJson(f._1.asInstanceOf[String], ResortsFactory.fromString(f._2)))//ResortSnapshotFactory.fromJson(f(0).asInstanceOf[String], ta).asInstanceOf[ResortSnapshot]
+      rvArray => rvArray.map(f => ResortSnapshotFactory.resortSnapshotFromJson(f._1.asInstanceOf[String], ResortsFactory.fromDBString(f._2)))//ResortSnapshotFactory.fromJson(f(0).asInstanceOf[String], ta).asInstanceOf[ResortSnapshot]
     ).map(snapshotArray => Ok(views.html.index(snapshotArray)))
+  }
+
+  def resort(resort: Resorts) = Action.async { implicit request: Request[AnyContent] => 
+    resortData.getAllSnapshotsForSingleResort(resort).map(
+      dataArray => dataArray.map(v => ResortSnapshotFactory.resortDataSnapshotFromJson(v._1, v._2.toString()))
+    ).map(dataArray => Ok(views.html.resort(dataArray, resort)))
   }
 
   def scrape() = Action.async { implicit request: Request[AnyContent] => 

--- a/app/dao/ResortData.scala
+++ b/app/dao/ResortData.scala
@@ -55,6 +55,12 @@ class ResortData @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
             rowValuesFuture.map(rv => rv.productIterator.toArray.dropRight(1).zip(tableNames))
         }
 
+        def getAllSnapshotsForSingleResort(resort: Resorts): Future[Array[String]] = {
+            val resortDBName = resort.databaseName
+            val q = sql"""select "#$resortDBName" FROM "RESORT_DATA" order by "CREATED"""".as[String].map(_.toArray)
+            db.run(q)
+        }
+
         def setSnapshotForResort(databaseSnapshots: Map[Resorts, DatabaseSnapshot]): Unit = {
             val insertAction = DBIO.seq(
                 resortData += (getResortSnapshot(ArapahoeBasin, databaseSnapshots).toJson(), new java.sql.Timestamp(new Date().getTime()))

--- a/app/dao/ResortData.scala
+++ b/app/dao/ResortData.scala
@@ -13,9 +13,6 @@ import scala.util.Success
 import scala.util.Failure
 import java.sql.Timestamp
 import slick.lifted.ProvenShape
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
-import slick.jdbc.meta.MTable
 import org.joda.time.Seconds
 
 import models._
@@ -55,9 +52,9 @@ class ResortData @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
             rowValuesFuture.map(rv => rv.productIterator.toArray.dropRight(1).zip(tableNames))
         }
 
-        def getAllSnapshotsForSingleResort(resort: Resorts): Future[Array[String]] = {
+        def getAllSnapshotsForSingleResort(resort: Resorts): Future[Array[(String, Timestamp)]] = {
             val resortDBName = resort.databaseName
-            val q = sql"""select "#$resortDBName" FROM "RESORT_DATA" order by "CREATED"""".as[String].map(_.toArray)
+            val q = sql"""select "#$resortDBName", "CREATED" FROM "RESORT_DATA" order by "CREATED"""".as[(String, Timestamp)].map(_.toArray)
             db.run(q)
         }
 

--- a/app/dao/ResortData.scala
+++ b/app/dao/ResortData.scala
@@ -4,7 +4,6 @@ import com.google.inject.Inject
 import play.api.db.slick.DatabaseConfigProvider
 import slick.jdbc.PostgresProfile.api._
 import scala.concurrent.ExecutionContext
-import play.api.mvc.AbstractController
 import play.api.db.slick.HasDatabaseConfigProvider
 import slick.jdbc.JdbcProfile
 import java.util.Date
@@ -13,7 +12,6 @@ import scala.util.Success
 import scala.util.Failure
 import java.sql.Timestamp
 import slick.lifted.ProvenShape
-import org.joda.time.Seconds
 
 import models._
 import scala.concurrent.Future

--- a/app/models/WebModel.scala
+++ b/app/models/WebModel.scala
@@ -23,15 +23,22 @@ object ResortSnapshotFactory {
         (JsPath \ "windDir").read[CardinalDirections]
     ) (ResortData.apply _)
 
-    def fromJson(data: String, resort:Resorts): ResortSnapshot = {
+    def resortSnapshotFromJson(data: String, resort:Resorts): ResortSnapshot = {
         val jsonData = Json.parse(data)
         val resortData = Json.fromJson[ResortData](jsonData)
         new ResortSnapshot(resort, resortData.get)
+    }
+
+    def ResortDataSnapshotFromJson(data: String, timestamp: String): ResortDataSnapshot = {
+        val jsonData = Json.parse(data)
+        val resortData = Json.fromJson[ResortData](jsonData)
+        new ResortDataSnapshot(timestamp, resortData.get)
     }
 }
 
 final case class ResortData(dailySnow: Int, baseDepth: Int, temperature: Int, windSpeed: Int, windDir: CardinalDirections) 
 final case class ResortSnapshot(resort: Resorts, resortData: ResortData)
+final case class ResortDataSnapshot(timestamp: TimeStamp, resortData: ResortData)
 
 object ResortsFactory {
     def fromString(resort: String): Resorts = {

--- a/app/models/WebModel.scala
+++ b/app/models/WebModel.scala
@@ -29,7 +29,7 @@ object ResortSnapshotFactory {
         new ResortSnapshot(resort, resortData.get)
     }
 
-    def ResortDataSnapshotFromJson(data: String, timestamp: String): ResortDataSnapshot = {
+    def resortDataSnapshotFromJson(data: String, timestamp: String): ResortDataSnapshot = {
         val jsonData = Json.parse(data)
         val resortData = Json.fromJson[ResortData](jsonData)
         new ResortDataSnapshot(timestamp, resortData.get)
@@ -38,7 +38,7 @@ object ResortSnapshotFactory {
 
 final case class ResortData(dailySnow: Int, baseDepth: Int, temperature: Int, windSpeed: Int, windDir: CardinalDirections) 
 final case class ResortSnapshot(resort: Resorts, resortData: ResortData)
-final case class ResortDataSnapshot(timestamp: TimeStamp, resortData: ResortData)
+final case class ResortDataSnapshot(timestamp: String, resortData: ResortData)
 
 object ResortsFactory {
     def fromString(resort: String): Resorts = {

--- a/app/models/WebModel.scala
+++ b/app/models/WebModel.scala
@@ -41,9 +41,15 @@ final case class ResortSnapshot(resort: Resorts, resortData: ResortData)
 final case class ResortDataSnapshot(timestamp: String, resortData: ResortData)
 
 object ResortsFactory {
-    def fromString(resort: String): Resorts = {
+    def fromDBString(resort: String): Resorts = {
         resort match {
             case ArapahoeBasin.databaseName => ArapahoeBasin
+            case default => throw new Error("Tried to read string that wasn't a Resort")
+        }
+    }
+    def fromNameString(resort: String): Resorts = {
+        resort match {
+            case resort if resort == ArapahoeBasin.toString() => ArapahoeBasin
             case default => throw new Error("Tried to read string that wasn't a Resort")
         }
     }

--- a/app/util/Binders.scala
+++ b/app/util/Binders.scala
@@ -1,0 +1,19 @@
+package util
+
+import java.util.UUID
+import play.api.mvc.PathBindable
+import models.Resorts
+import models.ResortsFactory
+
+object Binders {
+   implicit def resortsPathBinder = new PathBindable[Resorts] {
+      override def bind(key: String, value: String): Either[String, Resorts] = {
+         try {
+            Right(ResortsFactory.fromNameString(value))
+         } catch {
+            case e: Throwable => Left("This is not a valid resort")
+         }
+      }
+      override def unbind(key: String, value: Resorts): String = value.toString
+   }
+}

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,6 +1,6 @@
 @(snapshotArray: Array[ResortSnapshot])
 
-@main("Welcome to Play") {
+@main("Ski Resort Dashboard") {
   <h1>Ski Resort Dashboard</h1>
   <p>
     This is a small and simple dashboard to look up current and past conditions at a couple of Colorado Ski Resorts. Currently you can look at the 

--- a/app/views/resort.scala.html
+++ b/app/views/resort.scala.html
@@ -1,0 +1,18 @@
+@(snapshotArray: Array[ResortDataSnapshot], resort: Resorts)
+
+@main("Ski Resort Dashboard") {
+    <h1>@resort.toString()</h1>
+
+    <ul>
+        @for(snapshot <- snapshotArray) {
+            <li>Time: @snapshot.timestamp
+                24 Hour Snowfall: @snapshot.resortData.dailySnow inches 
+                Current Snow Depth: @snapshot.resortData.baseDepth inches
+                Current Temperature: @snapshot.resortData.temperature farenheit
+                Current Wind Speed: @snapshot.resortData.windSpeed mph
+                Current Wind Direction: @snapshot.resortData.windDir.toString()
+            </li>
+        }
+    </ul>
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -19,4 +19,4 @@ libraryDependencies += "com.typesafe.play" %% "play-slick" % "5.0.0"
 //TwirlKeys.templateImports += "com.example.controllers._"
 
 // Adds additional packages into conf/routes
-// play.sbt.routes.RoutesKeys.routesImport += "com.example.binders._"
+play.sbt.routes.RoutesKeys.routesImport += "util.Binders._"

--- a/conf/routes
+++ b/conf/routes
@@ -4,7 +4,11 @@
 # ~~~~
 
 # An example controller showing a sample home page
-GET     /                           controllers.HomeController.index()
+GET     /                               controllers.HomeController.index()
+
+# Route for getting all data from a single resort
+
+GET     /:resort                     controllers.HomeController.resort(resort: models.Resorts) 
 
 # Route for turning on scraping job
 GET     /scrape                         controllers.HomeController.scrape()


### PR DESCRIPTION
This PR adds a new flow that will allow users to see all of the collected data from a single resort. The changes include:

- Adding new method to the DAO which calls a plain SQL query with the resort column name interpolated into the query string
- Adds a new template that takes all of the snapshots for a particular resort and displays it in a list
- Creates a new route in the router config that takes in a resort as a dynamic route
- Creates a new route handler in the controller for a particular resort and grabs the resorts snapshots from the DAO and hands the results to the associated template
- Creates a new binder that pulls in a resort route and maps it to a resort type for the controller to use
- adds binder path to the build.sbt file
- Updates our Resort Factory with new methods for handling both DB strings and Route strings
- Updates resort model for handling resort data 