### PR TITLE
Fixing Scraping Issue

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -12,8 +12,5 @@ GET     /resorts/:resort                     controllers.HomeController.resort(r
 # Route for turning on scraping job
 GET     /scrape                         controllers.HomeController.scrape()
 
-# Route for turning on scraping job
-GET     /scrape                         controllers.HomeController.scrape()
-
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)

--- a/conf/routes
+++ b/conf/routes
@@ -7,8 +7,10 @@
 GET     /                               controllers.HomeController.index()
 
 # Route for getting all data from a single resort
+GET     /resorts/:resort                     controllers.HomeController.resort(resort: models.Resorts) 
 
-GET     /:resort                     controllers.HomeController.resort(resort: models.Resorts) 
+# Route for turning on scraping job
+GET     /scrape                         controllers.HomeController.scrape()
 
 # Route for turning on scraping job
 GET     /scrape                         controllers.HomeController.scrape()


### PR DESCRIPTION
After getting the scheduler script to work correctly, the actualy scrape job wasn't being run because the custom binder was being ran for the call (which was failing because scrape isn't a resort). 

I have preprended a static param in the route definitition so every resort url has to have /resorts in front of it. This will keep the scrape job from getting subjected to the custom binder