### PR TITLE
Adding POWDR Resorts Scrapers

### DIFF
--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -44,12 +44,12 @@ class HomeController @Inject()(val controllerComponents: ControllerComponents, v
   def scrape() = Action.async { implicit request: Request[AnyContent] => 
     var resortDataMap: Map[Resorts, DatabaseSnapshot] = Map[Resorts, DatabaseSnapshot]()
     var resortFutureSeq: ArrayBuffer[Future[Unit]] = ArrayBuffer.empty
-    new PowdrScraper(ws)
     resortFutureSeq.addOne(generateFuture(resortDataMap, ArapahoeBasin))
     resortFutureSeq.addOne(generateFuture(resortDataMap, Breckenridge))
     resortFutureSeq.addOne(generateFuture(resortDataMap, BeaverCreek))
     resortFutureSeq.addOne(generateFuture(resortDataMap, Vail))
     resortFutureSeq.addOne(generateFuture(resortDataMap, Keystone))
+    resortFutureSeq.addOne(generateFuture(resortDataMap, Eldora))
     Future.sequence(resortFutureSeq).map(futureArray => {
       resortData.setSnapshotForResort(resortDataMap.toMap)
       Ok

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -12,6 +12,7 @@ import scala.concurrent._
 import ExecutionContext.Implicits.global 
 import scrapers.ScraperFactory
 import play.api.libs.ws.WSClient
+import scrapers.PowdrScraper
 
 
 /**
@@ -43,7 +44,7 @@ class HomeController @Inject()(val controllerComponents: ControllerComponents, v
   def scrape() = Action.async { implicit request: Request[AnyContent] => 
     var resortDataMap: Map[Resorts, DatabaseSnapshot] = Map[Resorts, DatabaseSnapshot]()
     var resortFutureSeq: ArrayBuffer[Future[Unit]] = ArrayBuffer.empty
-    
+    new PowdrScraper(ws)
     resortFutureSeq.addOne(generateFuture(resortDataMap, ArapahoeBasin))
     resortFutureSeq.addOne(generateFuture(resortDataMap, Breckenridge))
     resortFutureSeq.addOne(generateFuture(resortDataMap, BeaverCreek))

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -50,6 +50,7 @@ class HomeController @Inject()(val controllerComponents: ControllerComponents, v
     resortFutureSeq.addOne(generateFuture(resortDataMap, Vail))
     resortFutureSeq.addOne(generateFuture(resortDataMap, Keystone))
     resortFutureSeq.addOne(generateFuture(resortDataMap, Eldora))
+    resortFutureSeq.addOne(generateFuture(resortDataMap, Copper))
     Future.sequence(resortFutureSeq).map(futureArray => {
       resortData.setSnapshotForResort(resortDataMap.toMap)
       Ok

--- a/app/dao/ResortData.scala
+++ b/app/dao/ResortData.scala
@@ -36,7 +36,8 @@ class ResortData @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
             columnCheckandAdd(Breckenridge),
             columnCheckandAdd(BeaverCreek),
             columnCheckandAdd(Vail),
-            columnCheckandAdd(Keystone)
+            columnCheckandAdd(Keystone),
+            columnCheckandAdd(Eldora)
         )
 
         db.run(setup).onComplete({
@@ -48,7 +49,7 @@ class ResortData @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
         def getLatestSnapshotForAllResorts: (Future[Array[(Any, String)]]) = {
             val q = resortData.sortBy(_.created.desc).take(1)
             val tableNames = resortData.baseTableRow.create_*.map(_.name).toArray
-            var rowValuesFuture: Future[(String, String, String, String, String, Timestamp)] = db.run(q.result).map(_.last)
+            var rowValuesFuture: Future[(String, String, String, String, String, String, Timestamp)] = db.run(q.result).map(_.last)
             rowValuesFuture.map(rv => rv.productIterator.toArray.dropRight(1).zip(tableNames))
         }
 
@@ -65,6 +66,7 @@ class ResortData @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
                  getResortSnapshot(BeaverCreek, databaseSnapshots).toJson(),
                  getResortSnapshot(Vail, databaseSnapshots).toJson(),
                  getResortSnapshot(Keystone, databaseSnapshots).toJson(),
+                 getResortSnapshot(Eldora, databaseSnapshots).toJson(),
                  new java.sql.Timestamp(new Date().getTime()))
             )
             db.run(insertAction).onComplete({
@@ -82,14 +84,15 @@ class ResortData @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
             return snapshotOption.get
         }
 
-        private class ResortDataSchema(tag: Tag) extends Table[(String, String, String, String, String, Timestamp)](tag, "RESORT_DATA") {
+        private class ResortDataSchema(tag: Tag) extends Table[(String, String, String, String, String, String, Timestamp)](tag, "RESORT_DATA") {
             def arapahoeBasin = column[String](ArapahoeBasin.databaseName)
             def breckenridge = column[String](Breckenridge.databaseName)
             def beaverCreek = column[String](BeaverCreek.databaseName)
             def vail = column[String](Vail.databaseName)
             def keystone = column[String](Keystone.databaseName)
+            def eldora = column[String](Eldora.databaseName)
             def created = column[Timestamp]("CREATED")
-            def * : ProvenShape[(String, String, String, String, String, Timestamp)] = 
-                (arapahoeBasin, breckenridge, beaverCreek, vail, keystone, created)
+            def * : ProvenShape[(String, String, String, String, String, String, Timestamp)] = 
+                (arapahoeBasin, breckenridge, beaverCreek, vail, keystone, eldora, created)
         }
     }

--- a/app/dao/ResortData.scala
+++ b/app/dao/ResortData.scala
@@ -37,7 +37,8 @@ class ResortData @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
             columnCheckandAdd(BeaverCreek),
             columnCheckandAdd(Vail),
             columnCheckandAdd(Keystone),
-            columnCheckandAdd(Eldora)
+            columnCheckandAdd(Eldora),
+            columnCheckandAdd(Copper)
         )
 
         db.run(setup).onComplete({
@@ -49,7 +50,7 @@ class ResortData @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
         def getLatestSnapshotForAllResorts: (Future[Array[(Any, String)]]) = {
             val q = resortData.sortBy(_.created.desc).take(1)
             val tableNames = resortData.baseTableRow.create_*.map(_.name).toArray
-            var rowValuesFuture: Future[(String, String, String, String, String, String, Timestamp)] = db.run(q.result).map(_.last)
+            var rowValuesFuture: Future[(String, String, String, String, String, String, String, Timestamp)] = db.run(q.result).map(_.last)
             rowValuesFuture.map(rv => rv.productIterator.toArray.dropRight(1).zip(tableNames))
         }
 
@@ -67,6 +68,7 @@ class ResortData @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
                  getResortSnapshot(Vail, databaseSnapshots).toJson(),
                  getResortSnapshot(Keystone, databaseSnapshots).toJson(),
                  getResortSnapshot(Eldora, databaseSnapshots).toJson(),
+                 getResortSnapshot(Copper, databaseSnapshots).toJson(),
                  new java.sql.Timestamp(new Date().getTime()))
             )
             db.run(insertAction).onComplete({
@@ -84,15 +86,16 @@ class ResortData @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
             return snapshotOption.get
         }
 
-        private class ResortDataSchema(tag: Tag) extends Table[(String, String, String, String, String, String, Timestamp)](tag, "RESORT_DATA") {
+        private class ResortDataSchema(tag: Tag) extends Table[(String, String, String, String, String, String, String, Timestamp)](tag, "RESORT_DATA") {
             def arapahoeBasin = column[String](ArapahoeBasin.databaseName)
             def breckenridge = column[String](Breckenridge.databaseName)
             def beaverCreek = column[String](BeaverCreek.databaseName)
             def vail = column[String](Vail.databaseName)
             def keystone = column[String](Keystone.databaseName)
             def eldora = column[String](Eldora.databaseName)
+            def copper = column[String](Copper.databaseName)
             def created = column[Timestamp]("CREATED")
-            def * : ProvenShape[(String, String, String, String, String, String, Timestamp)] = 
-                (arapahoeBasin, breckenridge, beaverCreek, vail, keystone, eldora, created)
+            def * : ProvenShape[(String, String, String, String, String, String, String, Timestamp)] = 
+                (arapahoeBasin, breckenridge, beaverCreek, vail, keystone, eldora, copper, created)
         }
     }

--- a/app/models/WebModel.scala
+++ b/app/models/WebModel.scala
@@ -56,6 +56,7 @@ object ResortsFactory {
             case BeaverCreek.databaseName => BeaverCreek
             case Vail.databaseName => Vail
             case Keystone.databaseName => Keystone
+            case Eldora.databaseName => Eldora
             case default => throw new Error("Tried to read string that wasn't a Resort")
         }
     }
@@ -66,11 +67,13 @@ object ResortsFactory {
             case resort if resort == BeaverCreek.toString() => BeaverCreek
             case resort if resort == Vail.toString() => Vail
             case resort if resort == Keystone.toString() => Keystone
+            case resort if resort == Eldora.toString() => Eldora
             case default => throw new Error("Tried to read string that wasn't a Resort")
         }
     }
 }
 sealed trait Resorts { val databaseName: String; val scrapeUrl: String }
+sealed trait PowdrResorts extends Resorts { val location_id: Int }
 case object ArapahoeBasin extends Resorts {
     override def toString: String = "Arapahoe-Basin"
     override val databaseName = "ARAPAHOE_BASIN"
@@ -97,4 +100,14 @@ case object Keystone extends Resorts {
     override def toString: String = "Keystone-Resort"
     override val databaseName: String = "KEYSTONE"
     override val scrapeUrl: String = "https://www.keystoneresort.com/api/PageApi/GetWeatherDataForHeader"   
+}
+
+case object Eldora extends PowdrResorts {
+    override def toString: String = "Eldora-Mountain-Resort"
+    override val databaseName: String = "ELDORA"
+    
+    override val scrapeUrl: String = "https://www.eldora.com/api/v1/dor/conditions"
+    
+    override val location_id: Int = 11
+    
 }

--- a/app/models/WebModel.scala
+++ b/app/models/WebModel.scala
@@ -57,6 +57,7 @@ object ResortsFactory {
             case Vail.databaseName => Vail
             case Keystone.databaseName => Keystone
             case Eldora.databaseName => Eldora
+            case Copper.databaseName => Copper
             case default => throw new Error("Tried to read string that wasn't a Resort")
         }
     }
@@ -68,6 +69,7 @@ object ResortsFactory {
             case resort if resort == Vail.toString() => Vail
             case resort if resort == Keystone.toString() => Keystone
             case resort if resort == Eldora.toString() => Eldora
+            case resort if resort == Copper.toString() => Copper
             case default => throw new Error("Tried to read string that wasn't a Resort")
         }
     }
@@ -105,9 +107,13 @@ case object Keystone extends Resorts {
 case object Eldora extends PowdrResorts {
     override def toString: String = "Eldora-Mountain-Resort"
     override val databaseName: String = "ELDORA"
-    
     override val scrapeUrl: String = "https://www.eldora.com/api/v1/dor/conditions"
-    
     override val location_id: Int = 11
-    
+}
+
+case object Copper extends PowdrResorts {
+    override def toString: String = "Copper-Mountain"
+    override val databaseName: String = "COPPER"
+    override val scrapeUrl: String = "https://www.coppercolorado.com/api/v1/dor/conditions"
+    override val location_id: Int = 7
 }

--- a/app/models/WebModel.scala
+++ b/app/models/WebModel.scala
@@ -70,30 +70,30 @@ object ResortsFactory {
         }
     }
 }
-sealed trait Resorts { val databaseName: String }
-sealed trait EpicResorts extends Resorts { val scrapeUrl: String }
+sealed trait Resorts { val databaseName: String; val scrapeUrl: String }
 case object ArapahoeBasin extends Resorts {
     override def toString: String = "Arapahoe-Basin"
     override val databaseName = "ARAPAHOE_BASIN"
+    override val scrapeUrl: String = "http://www.arapahoebasin.com"
 }
-case object Breckenridge extends EpicResorts {
+case object Breckenridge extends Resorts {
     override def toString: String = "Breckenridge"
     override val databaseName: String = "BRECKENRIDGE"
     override val scrapeUrl: String = "https://www.breckenridge.com/api/PageApi/GetWeatherDataForHeader"
 }
-case object BeaverCreek extends EpicResorts {
+case object BeaverCreek extends Resorts {
     override def toString: String = "Beaver-Creek"
     override val databaseName: String = "BEAVERCREEK"
     override val scrapeUrl: String = "https://www.beavercreek.com/api/PageApi/GetWeatherDataForHeader"
 }
 
-case object Vail extends EpicResorts {
+case object Vail extends Resorts {
     override def toString: String = "Vail"
     override val databaseName: String = "VAIL"
     override val scrapeUrl: String = "https://www.vail.com/api/PageApi/GetWeatherDataForHeader"
 }
 
-case object Keystone extends EpicResorts {
+case object Keystone extends Resorts {
     override def toString: String = "Keystone-Resort"
     override val databaseName: String = "KEYSTONE"
     override val scrapeUrl: String = "https://www.keystoneresort.com/api/PageApi/GetWeatherDataForHeader"   

--- a/app/scrapers/ABasinScraper.scala
+++ b/app/scrapers/ABasinScraper.scala
@@ -9,7 +9,7 @@ import net.ruippeixotog.scalascraper.model.Element
 import models._
 
 class ABasinScraper extends BaseScraper(ArapahoeBasin)  {
-    val conditionsLabels = browser.get("http://www.arapahoebasin.com") >> elementList(".ab-condition_sub")
+    val conditionsLabels = browser.get(ArapahoeBasin.scrapeUrl) >> elementList(".ab-condition_sub")
 
     protected override def scrape24HrSnowFall(): Int = {
         val dailySnowLabel = conditionsLabels.filter(el => el.text == "Past 24 Hrs")(0)

--- a/app/scrapers/BaseScraper.scala
+++ b/app/scrapers/BaseScraper.scala
@@ -24,7 +24,7 @@ object ScraperFactory {
       case BeaverCreek => new EpicScraper(ws, BeaverCreek)
       case Vail => new EpicScraper(ws, Vail)
       case Keystone => new EpicScraper(ws, Keystone)
-      
+      case Eldora => new PowdrScraper(ws, Eldora)
     }
   }
 }

--- a/app/scrapers/BaseScraper.scala
+++ b/app/scrapers/BaseScraper.scala
@@ -25,6 +25,7 @@ object ScraperFactory {
       case Vail => new EpicScraper(ws, Vail)
       case Keystone => new EpicScraper(ws, Keystone)
       case Eldora => new PowdrScraper(ws, Eldora)
+      case Copper => new PowdrScraper(ws, Copper)
     }
   }
 }

--- a/app/scrapers/EpicScraper.scala
+++ b/app/scrapers/EpicScraper.scala
@@ -1,23 +1,19 @@
 package scrapers
 
-import models.Breckenridge
 import javax.inject.Inject
 import play.api.libs.ws._
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.util.Success
-import scala.util.Failure
+import scala.concurrent.{ ExecutionContext, Future, Await }
+import scala.util.{ Success, Failure }
 import play.api.libs.json._
-import scala.concurrent.Await
 import scala.concurrent.duration._
-import models.EpicResorts
+import models.Resorts
 
 
 case class SnowMeasurement (Inches: String, Centimeters: String)
 case class SnowResult (Depth: SnowMeasurement, Description: String)
 
 
-class EpicScraper (ws: WSClient, resort: EpicResorts)(
+class EpicScraper (ws: WSClient, resort: Resorts)(
     implicit ec: ExecutionContext
 ) extends BaseScraper(resort)  {
   implicit val SnowMeasurementReads = Json.reads[SnowMeasurement]

--- a/app/scrapers/EpicScraper.scala
+++ b/app/scrapers/EpicScraper.scala
@@ -16,22 +16,22 @@ case class SnowResult (Depth: SnowMeasurement, Description: String)
 class EpicScraper (ws: WSClient, resort: Resorts)(
     implicit ec: ExecutionContext
 ) extends BaseScraper(resort)  {
-  implicit val SnowMeasurementReads = Json.reads[SnowMeasurement]
-  implicit val SnowResultReads = Json.reads[SnowResult]
+    implicit val SnowMeasurementReads = Json.reads[SnowMeasurement]
+    implicit val SnowResultReads = Json.reads[SnowResult]
 
-  private val request = ws.url(resort.scrapeUrl)
-  private val snowReportResult: Set[SnowResult] = Await.result(request.get().map { response =>
-    (response.json \ "SnowReportSections").validate[Set[SnowResult]]
-  }, 5.second).get
+    private val request = ws.url(resort.scrapeUrl)
+    private val snowReportResult: Set[SnowResult] = Await.result(request.get().map { response =>
+        (response.json \ "SnowReportSections").validate[Set[SnowResult]]
+    }, 5.second).get
 
-  // val snowReport = request.get().toCompletableFuture().get().asJson.get("SnowReportSections").asInstanceOf[ArrayNode];
+    // val snowReport = request.get().toCompletableFuture().get().asJson.get("SnowReportSections").asInstanceOf[ArrayNode];
 
-  protected def scrape24HrSnowFall(): Int = {
-    return snowReportResult.find(reportItem => reportItem.Description.contains("24 Hour")).get.Depth.Inches.toInt;
-  }
-  
-  protected def scrapeBaseDepth(): Int = {
-    return snowReportResult.find(reportItem => reportItem.Description.contains("Base")).get.Depth.Inches.toInt;
-  }
+    protected def scrape24HrSnowFall(): Int = {
+        return snowReportResult.find(reportItem => reportItem.Description.contains("24 Hour")).get.Depth.Inches.toInt;
+    }
+    
+    protected def scrapeBaseDepth(): Int = {
+        return snowReportResult.find(reportItem => reportItem.Description.contains("Base")).get.Depth.Inches.toInt;
+    }
   
 }

--- a/app/scrapers/EpicScraper.scala
+++ b/app/scrapers/EpicScraper.scala
@@ -9,13 +9,12 @@ import scala.concurrent.duration._
 import models.Resorts
 
 
-case class SnowMeasurement (Inches: String, Centimeters: String)
-case class SnowResult (Depth: SnowMeasurement, Description: String)
-
-
 class EpicScraper (ws: WSClient, resort: Resorts)(
     implicit ec: ExecutionContext
 ) extends BaseScraper(resort)  {
+    case class SnowMeasurement (Inches: String, Centimeters: String)
+    case class SnowResult (Depth: SnowMeasurement, Description: String)
+
     implicit val SnowMeasurementReads = Json.reads[SnowMeasurement]
     implicit val SnowResultReads = Json.reads[SnowResult]
 

--- a/app/scrapers/PowdrScraper.scala
+++ b/app/scrapers/PowdrScraper.scala
@@ -5,21 +5,29 @@ import models.Resorts
 import scala.concurrent.{ ExecutionContext, Await }
 import scala.concurrent.duration._
 import play.api.libs.json._
+import models.PowdrResorts
 
-class PowdrScraper (ws: WSClient)(
+class PowdrScraper (ws: WSClient, resort: PowdrResorts)(
     implicit ec: ExecutionContext
-) {
+) extends BaseScraper(resort) {
     case class SnowAmount(amount: Int, duration: String)
     case class SnowResult (items:Seq[SnowAmount], location_id: Int)
 
     implicit val SnowAmountReads = Json.reads[SnowAmount]
     implicit val SnowResultReads = Json.reads[SnowResult]
 
-    private val request = ws.url("https://www.eldora.com/api/v1/dor/conditions")
+    private val request = ws.url(resort.scrapeUrl)
     private val snowReportResult: SnowResult = Await.result(request.get().map { response =>
         (response.json \ "snowReport").validate[Set[SnowResult]]
-    }, 5.seconds).get.find(report => report.location_id == 11).get
+    }, 5.seconds).get.find(report => report.location_id == resort.location_id).get
 
-    println(snowReportResult)
+    override protected def scrape24HrSnowFall(): Int = {
+        snowReportResult.items.find(item => item.duration == "24 Hours").get.amount
+    }
+    
+    override protected def scrapeBaseDepth(): Int = {
+        snowReportResult.items.find(item => item.duration == "base-depth").get.amount
+    }
+    
     
 }

--- a/app/scrapers/PowdrScraper.scala
+++ b/app/scrapers/PowdrScraper.scala
@@ -1,0 +1,25 @@
+package scrapers
+
+import play.api.libs.ws.WSClient
+import models.Resorts
+import scala.concurrent.{ ExecutionContext, Await }
+import scala.concurrent.duration._
+import play.api.libs.json._
+
+class PowdrScraper (ws: WSClient)(
+    implicit ec: ExecutionContext
+) {
+    case class SnowAmount(amount: Int, duration: String)
+    case class SnowResult (items:Seq[SnowAmount], location_id: Int)
+
+    implicit val SnowAmountReads = Json.reads[SnowAmount]
+    implicit val SnowResultReads = Json.reads[SnowResult]
+
+    private val request = ws.url("https://www.eldora.com/api/v1/dor/conditions")
+    private val snowReportResult: SnowResult = Await.result(request.get().map { response =>
+        (response.json \ "snowReport").validate[Set[SnowResult]]
+    }, 5.seconds).get.find(report => report.location_id == 11).get
+
+    println(snowReportResult)
+    
+}


### PR DESCRIPTION
This PR adds a scraper class for Copper and Eldora since they are both under POWDR corporation and have the same snow conditions API. This PR includes:
- removal of the Epic Resorts trait and puts scraperUrl in the Resorts trait
- using ABasin model scraperUrl instead of hardcoded Url
- Added PowdrResort trait that extends Resort Trait and adds a location_id property
- Added PowdrScraper that takes in PowdrResort Models and passes them to base scraper
-- uses WS to grab JSON data from Powdr resorts and uses locationId on model to get snow report
- Added new Eldora model with scraper url
- Added Eldora to scrape route future list
- Added Eldora to scraper factory
- Added Eldora to resorts factory
- Added new Copper model with scraper url
- Added Copper to scrape route future list
- Added Copper to scraper factory
- Added Copper to resorts factory