### PR TITLE
Adding Winter Park Scraper

### DIFF
--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -13,6 +13,7 @@ import ExecutionContext.Implicits.global
 import scrapers.ScraperFactory
 import play.api.libs.ws.WSClient
 import scrapers.PowdrScraper
+import scrapers.WinterParkScraper
 
 
 /**
@@ -44,6 +45,7 @@ class HomeController @Inject()(val controllerComponents: ControllerComponents, v
   def scrape() = Action.async { implicit request: Request[AnyContent] => 
     var resortDataMap: Map[Resorts, DatabaseSnapshot] = Map[Resorts, DatabaseSnapshot]()
     var resortFutureSeq: ArrayBuffer[Future[Unit]] = ArrayBuffer.empty
+    new WinterParkScraper(ws)
     resortFutureSeq.addOne(generateFuture(resortDataMap, ArapahoeBasin))
     resortFutureSeq.addOne(generateFuture(resortDataMap, Breckenridge))
     resortFutureSeq.addOne(generateFuture(resortDataMap, BeaverCreek))

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -45,7 +45,7 @@ class HomeController @Inject()(val controllerComponents: ControllerComponents, v
   def scrape() = Action.async { implicit request: Request[AnyContent] => 
     var resortDataMap: Map[Resorts, DatabaseSnapshot] = Map[Resorts, DatabaseSnapshot]()
     var resortFutureSeq: ArrayBuffer[Future[Unit]] = ArrayBuffer.empty
-    new WinterParkScraper(ws)
+
     resortFutureSeq.addOne(generateFuture(resortDataMap, ArapahoeBasin))
     resortFutureSeq.addOne(generateFuture(resortDataMap, Breckenridge))
     resortFutureSeq.addOne(generateFuture(resortDataMap, BeaverCreek))
@@ -53,6 +53,8 @@ class HomeController @Inject()(val controllerComponents: ControllerComponents, v
     resortFutureSeq.addOne(generateFuture(resortDataMap, Keystone))
     resortFutureSeq.addOne(generateFuture(resortDataMap, Eldora))
     resortFutureSeq.addOne(generateFuture(resortDataMap, Copper))
+    resortFutureSeq.addOne(generateFuture(resortDataMap, WinterPark))
+    
     Future.sequence(resortFutureSeq).map(futureArray => {
       resortData.setSnapshotForResort(resortDataMap.toMap)
       Ok

--- a/app/dao/ResortData.scala
+++ b/app/dao/ResortData.scala
@@ -38,7 +38,8 @@ class ResortData @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
             columnCheckandAdd(Vail),
             columnCheckandAdd(Keystone),
             columnCheckandAdd(Eldora),
-            columnCheckandAdd(Copper)
+            columnCheckandAdd(Copper),
+            columnCheckandAdd(WinterPark)
         )
 
         db.run(setup).onComplete({
@@ -50,7 +51,7 @@ class ResortData @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
         def getLatestSnapshotForAllResorts: (Future[Array[(Any, String)]]) = {
             val q = resortData.sortBy(_.created.desc).take(1)
             val tableNames = resortData.baseTableRow.create_*.map(_.name).toArray
-            var rowValuesFuture: Future[(String, String, String, String, String, String, String, Timestamp)] = db.run(q.result).map(_.last)
+            var rowValuesFuture: Future[(String, String, String, String, String, String, String, String, Timestamp)] = db.run(q.result).map(_.last)
             rowValuesFuture.map(rv => rv.productIterator.toArray.dropRight(1).zip(tableNames))
         }
 
@@ -69,6 +70,7 @@ class ResortData @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
                  getResortSnapshot(Keystone, databaseSnapshots).toJson(),
                  getResortSnapshot(Eldora, databaseSnapshots).toJson(),
                  getResortSnapshot(Copper, databaseSnapshots).toJson(),
+                 getResortSnapshot(WinterPark, databaseSnapshots).toJson(),
                  new java.sql.Timestamp(new Date().getTime()))
             )
             db.run(insertAction).onComplete({
@@ -86,7 +88,7 @@ class ResortData @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
             return snapshotOption.get
         }
 
-        private class ResortDataSchema(tag: Tag) extends Table[(String, String, String, String, String, String, String, Timestamp)](tag, "RESORT_DATA") {
+        private class ResortDataSchema(tag: Tag) extends Table[(String, String, String, String, String, String, String, String, Timestamp)](tag, "RESORT_DATA") {
             def arapahoeBasin = column[String](ArapahoeBasin.databaseName)
             def breckenridge = column[String](Breckenridge.databaseName)
             def beaverCreek = column[String](BeaverCreek.databaseName)
@@ -94,8 +96,9 @@ class ResortData @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
             def keystone = column[String](Keystone.databaseName)
             def eldora = column[String](Eldora.databaseName)
             def copper = column[String](Copper.databaseName)
+            def winterPark = column[String](WinterPark.databaseName)
             def created = column[Timestamp]("CREATED")
-            def * : ProvenShape[(String, String, String, String, String, String, String, Timestamp)] = 
-                (arapahoeBasin, breckenridge, beaverCreek, vail, keystone, eldora, copper, created)
+            def * : ProvenShape[(String, String, String, String, String, String, String, String, Timestamp)] = 
+                (arapahoeBasin, breckenridge, beaverCreek, vail, keystone, eldora, copper, winterPark, created)
         }
     }

--- a/app/models/WebModel.scala
+++ b/app/models/WebModel.scala
@@ -58,6 +58,7 @@ object ResortsFactory {
             case Keystone.databaseName => Keystone
             case Eldora.databaseName => Eldora
             case Copper.databaseName => Copper
+            case WinterPark.databaseName => WinterPark
             case default => throw new Error("Tried to read string that wasn't a Resort")
         }
     }
@@ -70,6 +71,7 @@ object ResortsFactory {
             case resort if resort == Keystone.toString() => Keystone
             case resort if resort == Eldora.toString() => Eldora
             case resort if resort == Copper.toString() => Copper
+            case resport if resort == WinterPark.toString() => WinterPark
             case default => throw new Error("Tried to read string that wasn't a Resort")
         }
     }
@@ -116,4 +118,10 @@ case object Copper extends PowdrResorts {
     override val databaseName: String = "COPPER"
     override val scrapeUrl: String = "https://www.coppercolorado.com/api/v1/dor/conditions"
     override val location_id: Int = 7
+}
+
+case object WinterPark extends Resorts {
+    override def toString: String = "Winter-Park"
+    override val databaseName: String = "WINTERPARK"
+    override val scrapeUrl: String = "https://mtnpowder.com/feed?resortId=5"
 }

--- a/app/scrapers/BaseScraper.scala
+++ b/app/scrapers/BaseScraper.scala
@@ -26,6 +26,7 @@ object ScraperFactory {
       case Keystone => new EpicScraper(ws, Keystone)
       case Eldora => new PowdrScraper(ws, Eldora)
       case Copper => new PowdrScraper(ws, Copper)
+      case WinterPark => new WinterParkScraper(ws)
     }
   }
 }

--- a/app/scrapers/WinterParkScraper.scala
+++ b/app/scrapers/WinterParkScraper.scala
@@ -3,15 +3,20 @@ package scrapers
 import play.api.libs.ws.WSClient
 import scala.concurrent.{ ExecutionContext, Await }
 import scala.concurrent.duration._
+import models.WinterPark
 
 class WinterParkScraper (ws: WSClient)(
 implicit ec: ExecutionContext
-) extends {
-    private val request = ws.url("https://mtnpowder.com/feed?resortId=5")
+) extends BaseScraper(WinterPark) {
+
+
+
+    private val request = ws.url(WinterPark.scrapeUrl)
     private val snowReportResult = Await.result(request.get().map { response => 
         (response.json \ "SnowReport" \ "MidMountainArea")
     }, 5.second).get
-    println(snowReportResult)
-    println((snowReportResult \ "BaseIn").get.as[String].toFloat.toInt)
-    println((snowReportResult \ "Last24HoursIn").get.as[String].toFloat.toInt)
+
+    override protected def scrape24HrSnowFall(): Int = (snowReportResult \ "Last24HoursIn").get.as[String].toFloat.toInt
+
+    override protected def scrapeBaseDepth(): Int = (snowReportResult \ "BaseIn").get.as[String].toFloat.toInt
 }

--- a/app/scrapers/WinterParkScraper.scala
+++ b/app/scrapers/WinterParkScraper.scala
@@ -1,0 +1,17 @@
+package scrapers
+
+import play.api.libs.ws.WSClient
+import scala.concurrent.{ ExecutionContext, Await }
+import scala.concurrent.duration._
+
+class WinterParkScraper (ws: WSClient)(
+implicit ec: ExecutionContext
+) extends {
+    private val request = ws.url("https://mtnpowder.com/feed?resortId=5")
+    private val snowReportResult = Await.result(request.get().map { response => 
+        (response.json \ "SnowReport" \ "MidMountainArea")
+    }, 5.second).get
+    println(snowReportResult)
+    println((snowReportResult \ "BaseIn").get.as[String].toFloat.toInt)
+    println((snowReportResult \ "Last24HoursIn").get.as[String].toFloat.toInt)
+}


### PR DESCRIPTION
This adds a scraper for Winter Park that hits the feed endpoint using the 'ws' library and extracts the Base Depth and 24 Hour Snowfall. Changes in this PR include:
- New scraper for Winter Park that extends the BaseScraper
- - Scraper makes API call and uses play JSON library to extract base depth and 24 hour snow fall
- Added new Winter Park model with scraper url
- Added Winter Park to scrape route future list
- Added Winter Park to scraper factory
- Added Winter Park to resorts factory