### PR TITLE
[issue44] Added Semantic Release GitHub Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,54 @@
+# GitHub Action For using Semantic Release
+
+name: Release
+
+on: 
+  push:
+    branches: 
+      - main
+      - next
+      - next-major
+      - alpha
+      - beta
+      
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v3
+        with:
+          semantic_version: 19.0.2
+          branches: |    
+            [
+              '+([0-9])?(.{+([0-9]),x}).x',
+              'main', 
+              'next', 
+              'next-major', 
+              {
+                name: 'beta', 
+                prerelease: true
+              }, 
+              {
+                name: 'alpha', 
+                prerelease: true
+              }
+            ]
+          extra_plugins: |
+            @semantic-release/changelog@6.0.1
+            @semantic-release/git@10.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Print Results
+        if: steps.semantic.outputs.new_release_published == 'true'
+          run: |
+            echo ${{ steps.semantic.outputs.new_release_version }}
+            echo ${{ steps.semantic.outputs.new_release_major_version }}
+            echo ${{ steps.semantic.outputs.new_release_minor_version }}
+            echo ${{ steps.semantic.outputs.new_release_patch_version }}
+
+  

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/npm",
+    "@semantic-release/github",
+    "@semantic-release/changelog",
+    "@semantic-release/git"
+  ]
+}


### PR DESCRIPTION
This PR adds the Semantic Release GitHub Action to my workflow. The reason behind doing this is so I can automatically bump my release version based on my commits. More information on this can be read on the home page of the wiki. The changes in this PR include:
- adding GitHub Action Workflow .yaml file which
-- uses Semantic Release Action to bump my tag version
-- Outputs release verison when finished
- added .releaserc which contains extra packages for Semantic Release to use
- Added tags to all of the commits in main.