### PR TITLE
Fixing Issues With Release Pipeline

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -2,7 +2,6 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/npm",
     "@semantic-release/github",
     "@semantic-release/changelog",
     "@semantic-release/git"


### PR DESCRIPTION
The release pipeline is still failing due to a number of small issues. This PR fixes them with changes that include:
- Removing semantic-release/npm plugin
- - I don't have any npm packages being published and don't have a package.json
- Updating tags 
- - SInce the pipeline didn't work on my last merge, I need to update the tags in order to keep in line with the release scheme I am using. This allow semantic release to keep the correct tag when it does start to work

Fixes #48