### PR TITLE
Updating Secrets Key

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,8 +41,7 @@ jobs:
             @semantic-release/changelog@6.0.1
             @semantic-release/git@10.0.1
         env:
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - name: Print Results
         if: steps.semantic.outputs.new_release_published == 'true'
         run: |


### PR DESCRIPTION
Updating the secrets key uses in for the GITHUB_TOKEN parameter of the semantic release action. Also removing NPM_TOKEN since we aren't using the npm plugin.