### PR TITLE
Add Token to Checkout GitHub Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v3


### PR DESCRIPTION
According to the post mentioned in the attached issue, in order for @semantic-release/git to have permissions to checkin the commit log, the checkout action also needs to have the Personal Access Token passed to it. This PR includes:
- updated tags
- added token parameter to Checkout action

Fixes #53