### PR TITLE
[Issue58] Migrate to Fly.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,6 @@ on:
       - next-major
       - alpha
       - beta
-      
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -56,12 +55,11 @@ jobs:
           echo ${{ steps.semantic-release.outputs.new_release_major_version }}
           echo ${{ steps.semantic-release.outputs.new_release_minor_version }}
           echo ${{ steps.semantic-release.outputs.new_release_patch_version }}
-      - name: Deploy To Heroku #Dummy Commit To Trigger Release
+      - name: Deploy To Fly.io #Dummy Commit To Trigger Release
         if: steps.semantic-release.outputs.new_release_published == 'true'
-        uses: akhileshns/heroku-deploy@v3.12.12 # This is the action
-        with:
-          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
-          heroku_app_name: "ski-resort-dashboard" #Must be unique in Heroku
-          heroku_email: "gibsta269@gmail.com"
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        uses: superfly/flyctl-actions/setup-flyctl@master # This is the action
+        run: flyctl deploy --remote-only
 
   

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,13 +1,15 @@
 # https://www.playframework.com/documentation/latest/Configuration
 play.http.secret.key=${?APPLICATION_SECRET}
-play.filters.hosts.allowed = ["localhost", ".local", "127.0.0.1", "ski-resort-dashboard.herokuapp.com"]
+play.filters.hosts.allowed = ["localhost", ".local", "127.0.0.1", "ski-resort-dashboard.fly.dev"]
 slick.dbs.default {
   profile = "slick.jdbc.PostgresProfile$"
   db {
     driver = "org.postgresql.Driver"
     url="jdbc:postgresql://127.0.0.1:5432/ski_resort_dashboard?password=skidashboard&user=skidashboard"
-    url=${?JDBC_DATABASE_URL}
+    url=${?DATABASE_URL}
     numThreads=2
     maxConnections=2
   }
 }
+
+

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,47 @@
+# fly.toml file generated for ski-resort-dashboard on 2022-10-24T12:00:52-06:00
+
+app = "ski-resort-dashboard"
+kill_signal = "SIGINT"
+kill_timeout = 5
+
+[env]
+  PORT = "8080"
+
+[build]
+  builder = "heroku/buildpacks:latest"
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+  cmd = []
+  entrypoint = []
+  exec = []
+
+[processes]
+  app = "target/universal/stage/bin/ski-resort-dashboard-backend -Dhttp.port=$PORT"
+
+[[services]]
+  http_checks = []
+  internal_port = 8080
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"


### PR DESCRIPTION
This PR adds changes to migrate production servers from Heroku to Fly.io. Changes in this PR include:
- Changing GitHub workflow to deploy to fly.io instead of Heroku
- Updating the application configuration to point to the Fly.io DATABASE_URL environment variable directly instead of the Heroku Buildpacks JDBC_DATABASE_URL
-- This allows me to turn off SSL for the Fly.io postgres connection since Fly.io doesn't support SSL for its internal databases
- Adding fly.toml file to build the project correctly in Fly.io