### PR TITLE
[Issue66] Setting Up Project For Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,9 @@
+FROM gitpod/workspace-postgresql
+
+RUN brew install scala
+
+RUN brew install sbt
+
+RUN brew install scalaenv
+
+RUN scalaenv install scala-2.13.6 && scalaenv global scala-2.13.6

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: sbt run
+
+ports:
+  - port: 9000
+    onOpen: open-preview

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,6 +1,6 @@
 # https://www.playframework.com/documentation/latest/Configuration
 play.http.secret.key=${?APPLICATION_SECRET}
-play.filters.hosts.allowed = ["localhost", ".local", "127.0.0.1", "ski-resort-dashboard.fly.dev"]
+play.filters.hosts.allowed = ["localhost", ".local", "127.0.0.1", "ski-resort-dashboard.fly.dev", ".gitpod.io"]
 slick.dbs.default {
   profile = "slick.jdbc.PostgresProfile$"
   db {


### PR DESCRIPTION
I want to be able to develop the project remotely when I am traveling and Gitpod is just the tool that allows me to do that. However, this project requires dependencies and toolchains that get removed every time a workspace is stopped or deleted (which happens after 14 days of inactivity). I also need to connect it to a Postgres database and my prod database is not available without tunnelling (nor should I be using prod for dev purposes anyways). To automate the setup process and create a postgres database on the fly, I have added a docker and yaml files that do just that. Changes in this PR include:
- added gitpod.yml file: This points gitpod env setup at my custom docker file and runs the server on workspace init
- added gitpod.Dockerfile: This uses the gitpod dockerfile for postgres setup and installs all the scala dependencies
- changed application.cong: Added gitpod to allowed hosts