### PR TITLE
[Issue 69] Migrating From Heroku to Oracle Cloud

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,10 +7,7 @@ on:
   push:
     branches: 
       - main
-      - next
-      - next-major
-      - alpha
-      - beta
+      
 jobs:
   release:
     name: Release New Version
@@ -54,23 +51,10 @@ jobs:
           echo ${{ steps.semantic-release.outputs.new_release_major_version }}
           echo ${{ steps.semantic-release.outputs.new_release_minor_version }}
           echo ${{ steps.semantic-release.outputs.new_release_patch_version }}
-  deploy:
-    name: Deploy App To Fly.io
-    runs-on: ubuntu-latest
-    needs: release
-    environment: 
-      name: Production
-      url: https://ski-resort-dashboard.fly.dev
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.CHECKOUT_TOKEN }}
-      - name: Install Flyctl      
-        uses: superfly/flyctl-actions/setup-flyctl@master
-      - name: Deploy To Fly.io
-        env: 
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-        run: flyctl deploy
+      - name: Deploy to Dokku
+        uses: dokku/github-action@master
+        with: 
+          git_remote_url: 'ssh://deploy.ski-resort-dashboard.laughingmanstudios.us.to:22/ski-resort-dashboard'
+          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
+
   

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,6 +1,12 @@
 # https://www.playframework.com/documentation/latest/Configuration
 play.http.secret.key=${?APPLICATION_SECRET}
-play.filters.hosts.allowed = ["localhost", ".local", "127.0.0.1", "ski-resort-dashboard.fly.dev", ".gitpod.io"]
+play.filters.hosts.allowed = [
+  "localhost", 
+  ".local", 
+  "127.0.0.1",
+  ".gitpod.io",
+  "app.ski-resort-dashboard.laughing-man-studios.us.to"
+]
 slick.dbs.default {
   profile = "slick.jdbc.PostgresProfile$"
   db {


### PR DESCRIPTION
Since Heroku is getting rid of its free tier, I am migrating the production site of ski-resort-dashboard to a different service. I tried to use Fly.io, but their virtual machines do not have enough memory for the application to function correctly. I have found Oracle Cloud, which offers bare 2 VMs (no PaaS features) and 2 volume storage blocks for free. I have set up Dokku on one of the VMs to give me the PaaS features and am updating the github actions and secrets to push to there instead of Heroku.