### PR TITLE
[Issue 65] Updating scrape url

### DIFF
--- a/.github/workflows/scrape.yaml
+++ b/.github/workflows/scrape.yaml
@@ -16,4 +16,4 @@ jobs:
     - name: curl
       uses: wei/curl@master
       with:
-        args: https://ski-resort-dashboard.fly.dev/scrape
+        args: http://ski-resort-dashboard.laughing-man-studios.us.to/scrape


### PR DESCRIPTION
This PR updates the scape url in the Scrape worflow so it hits the new production domain.
Changes include:

- Updating Scrape workflow with correct scrape URL