### PR TITLE
[Issue 82] Adding Home Page Styles for Mobile

### DIFF
--- a/app/assets/stylesheets/_common.scss
+++ b/app/assets/stylesheets/_common.scss
@@ -12,3 +12,4 @@ $white: white;
 $black: black;
 $green: #749c75;
 $red: #B98B82;
+$gray: rgb(238, 238, 238);

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,0 +1,47 @@
+@import "./common";
+
+body {
+    background-color: $white;
+    font-family: Arial, Helvetica, sans-serif;
+
+    #container {
+        margin: 3rem;
+        padding: 1rem 3rem;
+        background-color: $gray;
+
+        h1 {
+            text-align: center;
+            color: $red;
+            font-size: 3rem;
+        }
+    
+        #description {
+            text-align: center;
+            font-size: smaller ;
+        }
+    
+        .resort-card {
+            border: 1rem solid $green;
+            background-color: $blue;
+            color: $white;
+            padding: 2rem 5rem;
+            margin: 2rem 0;
+    
+            h3 {
+                text-align: center;
+            }
+    
+            .primary {
+                margin: auto;
+            }
+            
+            .secondary {
+                display: none;
+            }
+    
+            .tertiary {
+                display: none;
+            }
+        }
+    }
+}

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,23 +1,29 @@
 @(snapshotArray: Array[ResortSnapshot])
 
 @main("Ski Resort Dashboard","stylesheets/home.css") {
-  <h1>Ski Resort Dashboard</h1>
-  <p>
-    This is a small and simple dashboard to look up current and past conditions at a couple of Colorado Ski Resorts. Currently you can look at the 
-    current snow depth, the amount of snow that has fallen in the last 24 hours, the current temperature, the current wind speed, and the current wind
-    direction. I sample this data for all of the resorts two times a day, once in the morning and once in the afternoon. You can see all of the 
-    data that I have collected so far using the graphs on each resort page. Enjoy!
-  </p>
-
-  @for(resortSnapshot <- snapshotArray) {
-    <div class="resort-card">
-      <h3>@resortSnapshot.resort.toString()</h3>
-      <img src="@routes.Assets.at("images/"+ resortSnapshot.resort.toString() +".png")" title="@resortSnapshot.resort.toString()"/>
-      <p class="snow-day">24 Hour Snowfall: @resortSnapshot.resortData.dailySnow inches</p> 
-      <p class="snow-total">Current Snow Depth: @resortSnapshot.resortData.baseDepth inches</p>
-      <p class="temp">Current Temperature: @resortSnapshot.resortData.temperature farenheit</p>
-      <p class="wind-speed">Current Wind Speed: @resortSnapshot.resortData.windSpeed mph</p>
-      <p class="wind-dir">Current Wind Direction: @resortSnapshot.resortData.windDir.toString()</p>
-    </div>
-  }
+  <div id="container">
+    <h1>Ski Resort Dashboard</h1>
+    <p id="description">
+      This is a small and simple dashboard to look up current and past conditions at a couple of Colorado Ski Resorts. Currently you can look at the 
+      current snow depth, the amount of snow that has fallen in the last 24 hours, the current temperature, the current wind speed, and the current wind
+      direction. I sample this data for all of the resorts two times a day, once in the morning and once in the afternoon. You can see all of the 
+      data that I have collected so far using the graphs on each resort page. Enjoy!
+    </p>
+  
+    @for(resortSnapshot <- snapshotArray) {
+      <div class="resort-card">
+        <h3>@resortSnapshot.resort.toString()</h3>
+        <img class="tertiary" src="@routes.Assets.at("images/"+ resortSnapshot.resort.toString() +".png")" title="@resortSnapshot.resort.toString()"/>
+        <div class="primary">
+          <p>24 Hour Snowfall: @resortSnapshot.resortData.dailySnow inches</p> 
+          <p>Current Snow Depth: @resortSnapshot.resortData.baseDepth inches</p>
+          <p>Current Temperature: @resortSnapshot.resortData.temperature farenheit</p>
+        </div>
+        <div class="secondary">
+          <p>Current Wind Speed: @resortSnapshot.resortData.windSpeed mph</p>
+          <p>Current Wind Direction: @resortSnapshot.resortData.windDir.toString()</p>
+        </div>
+      </div>
+    }
+  </div>
 }


### PR DESCRIPTION
This PR adds base styles and styles that are specific to the mobile view for the site. I'm taking a mobile first approach to styles, so these will be the base stylse and media queries will change the styles for the larger view types. This doesn't include styles for the nav-bar because that is a separate component. Changes in this PR include:
- adding gray color to common stylesheet
- adding home stylesheet for home page
- updating classes and html to work with home stylesheet

Closes #82