### PR TITLE
[Issue 92] Fixing Powdr Scrapers

### DIFF
--- a/app/models/WebModel.scala
+++ b/app/models/WebModel.scala
@@ -109,14 +109,14 @@ case object Keystone extends Resorts {
 case object Eldora extends PowdrResorts {
     override def toString: String = "Eldora-Mountain-Resort"
     override val databaseName: String = "ELDORA"
-    override val scrapeUrl: String = "https://www.eldora.com/api/v1/dor/conditions"
+    override val scrapeUrl: String = "https://api.eldora.com/api/v1/dor/conditions"
     override val location_id: Int = 11
 }
 
 case object Copper extends PowdrResorts {
     override def toString: String = "Copper-Mountain"
     override val databaseName: String = "COPPER"
-    override val scrapeUrl: String = "https://www.coppercolorado.com/api/v1/dor/conditions"
+    override val scrapeUrl: String = "https://api.coppercolorado.com/api/v1/dor/conditions"
     override val location_id: Int = 7
 }
 

--- a/app/scrapers/PowdrScraper.scala
+++ b/app/scrapers/PowdrScraper.scala
@@ -19,15 +19,17 @@ class PowdrScraper (ws: WSClient, resort: PowdrResorts)(
 
     private val request = ws.url(resort.scrapeUrl)
     private val snowReportResult: SnowResult = Await.result(request.get().map { response =>
-        (response.json \ "snowReport1234").validate[Set[SnowResult]]
+        (response.json \ "snowReport").validate[Set[SnowResult]]
     }, 5.seconds).getOrElse(Set(defaultResult))
         .find(report => report.location_id == resort.location_id).getOrElse(defaultResult)
 
     override protected def scrape24HrSnowFall(): Int = {
+        print(snowReportResult.items)
         snowReportResult.items.find(item => item.duration == "24 Hours").getOrElse(SnowAmount(0,"")).amount
     }
     
     override protected def scrapeBaseDepth(): Int = {
+        print(snowReportResult.items)
         snowReportResult.items.find(item => item.duration == "base-depth").getOrElse(SnowAmount(0,"")).amount
     }
     


### PR DESCRIPTION
It looks like the Powdr resorts api has changed its domain from _www.<resort\>.com/api_ to _api.\<resort>.com/api_. Funny enough, the change went through for both copper and eldora, but they only removed the old API domain for eldora, but kept it for copper (so the copper scraper was still working). This PR updates both scrape URLs to use the new domain. The JSON payload for both resorts had changed a little bit, so it wasn't grabbing the data anyways. This PR changes include:

- Updating Powdr resort scrapers with the correct URLs
- Changing scraper logic to look at right JSON key for data

Closes #92