### PR TITLE
[Issue 94] Fix Epic Scrapers

### DIFF
--- a/app/models/WebModel.scala
+++ b/app/models/WebModel.scala
@@ -86,24 +86,24 @@ case object ArapahoeBasin extends Resorts {
 case object Breckenridge extends Resorts {
     override def toString: String = "Breckenridge"
     override val databaseName: String = "BRECKENRIDGE"
-    override val scrapeUrl: String = "https://www.breckenridge.com/api/PageApi/GetWeatherDataForHeader"
+    override val scrapeUrl: String = "https://www.breckenridge.com/the-mountain/mountain-conditions/snow-and-weather-report.aspx"
 }
 case object BeaverCreek extends Resorts {
     override def toString: String = "Beaver-Creek"
     override val databaseName: String = "BEAVERCREEK"
-    override val scrapeUrl: String = "https://www.beavercreek.com/api/PageApi/GetWeatherDataForHeader"
+    override val scrapeUrl: String = "https://www.beavercreek.com/the-mountain/mountain-conditions/snow-and-weather-report.aspx"
 }
 
 case object Vail extends Resorts {
     override def toString: String = "Vail"
     override val databaseName: String = "VAIL"
-    override val scrapeUrl: String = "https://www.vail.com/api/PageApi/GetWeatherDataForHeader"
+    override val scrapeUrl: String = "https://www.vail.com/the-mountain/mountain-conditions/snow-and-weather-report.aspx"
 }
 
 case object Keystone extends Resorts {
     override def toString: String = "Keystone-Resort"
     override val databaseName: String = "KEYSTONE"
-    override val scrapeUrl: String = "https://www.keystoneresort.com/api/PageApi/GetWeatherDataForHeader"   
+    override val scrapeUrl: String = "https://www.keystoneresort.com/the-mountain/mountain-conditions/snow-and-weather-report.aspx"   
 }
 
 case object Eldora extends PowdrResorts {

--- a/app/scrapers/BaseScraper.scala
+++ b/app/scrapers/BaseScraper.scala
@@ -20,10 +20,10 @@ object ScraperFactory {
   ): BaseScraper = {
     resort match {
       case ArapahoeBasin => new ABasinScraper
-      case Breckenridge => new EpicScraper(ws, Breckenridge)
-      case BeaverCreek => new EpicScraper(ws, BeaverCreek)
-      case Vail => new EpicScraper(ws, Vail)
-      case Keystone => new EpicScraper(ws, Keystone)
+      case Breckenridge => new EpicScraper(Breckenridge)
+      case BeaverCreek => new EpicScraper(BeaverCreek)
+      case Vail => new EpicScraper(Vail)
+      case Keystone => new EpicScraper(Keystone)
       case Eldora => new PowdrScraper(ws, Eldora)
       case Copper => new PowdrScraper(ws, Copper)
       case WinterPark => new WinterParkScraper(ws)

--- a/app/scrapers/PowdrScraper.scala
+++ b/app/scrapers/PowdrScraper.scala
@@ -24,12 +24,10 @@ class PowdrScraper (ws: WSClient, resort: PowdrResorts)(
         .find(report => report.location_id == resort.location_id).getOrElse(defaultResult)
 
     override protected def scrape24HrSnowFall(): Int = {
-        print(snowReportResult.items)
         snowReportResult.items.find(item => item.duration == "24 Hours").getOrElse(SnowAmount(0,"")).amount
     }
     
     override protected def scrapeBaseDepth(): Int = {
-        print(snowReportResult.items)
         snowReportResult.items.find(item => item.duration == "base-depth").getOrElse(SnowAmount(0,"")).amount
     }
     


### PR DESCRIPTION
Only 2 of the 4 Epic resorts were including the snow report data in the API call I was using to get said data. Since this was unreliable for all resorts, I have decided to just scrape their pages instead. Unfortunatly they populate the snow report elements with JSON data included within the page using JavaScript. Jsoup only looks at raw HTML responses, so I resorted to using Jsoup to find the script tag with the data in it, and regex to get the data out of the tag. PR changes include:
- revamping epic scraper to use Jsoup and regex to get data
- removing ws from epic scraper arguments 
- removing print statements
- updating epic resorts scraping URLs

Closes #94 