### PR TITLE
[Issue 96] Fixing Epic Scraper in Prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN sbt universal:packageZipTarball &&\
     echo ski-resort-dashboard-$(sbt --error 'print version') > version.txt &&\ 
 	echo "#!/bin/bash\n$(cat version.txt)/bin/ski-resort-dashboard" > run.sh
 
-FROM eclipse-temurin:8-jre-alpine
+FROM eclipse-temurin:11-jre-alpine
 RUN apk add --no-cache bash
 WORKDIR /app
 COPY --from=builder /app/target/universal/*.tgz \


### PR DESCRIPTION
Apparently there is a bug with JRE 8 that mucks with SSL connections. Although it didn't seem to affect the scala ws library, it does seem to effect the Jsoup library which is what I am using to scrape the Snow Report pages on the epic resorts. After doing some testing in the play-with-docker web app, I'm pretty confident that switching the Running Docker image to use JRE 11 should fix the issue. PR changes include:
- Switching Runtime Docker image to eclipise-temuring JRE 11

Closes #96