### PR TITLE
[Issue 105] Update individual resort data format

### DIFF
--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -39,7 +39,7 @@ class HomeController @Inject()(val controllerComponents: ControllerComponents, v
   def resort(resort: Resorts) = Action.async { implicit request: Request[AnyContent] => 
     resortData.getAllSnapshotsForSingleResort(resort).map(
       dataArray => dataArray.map(v => ResortSnapshotFactory.resortDataSnapshotFromJson(v._1, v._2.toString()))
-    ).map(dataArray => Ok(views.html.resort(generateGraphData(dataArray), resort, ResortSnapshotFactory.resortsList)))
+    ).map(dataArray => Ok(views.html.resort(new GraphData(dataArray), resort, ResortSnapshotFactory.resortsList)))
   }
 
   def scrape() = Action.async { implicit request: Request[AnyContent] => 
@@ -63,15 +63,5 @@ class HomeController @Inject()(val controllerComponents: ControllerComponents, v
         resortDataMap.put(resort, scraper.scrapeResort())
       } catch { case e: Exception => println(e.printStackTrace()) }
     }
-  }
-
-  private def generateGraphData(dataArray: Array[ResortDataSnapshot]): GraphData = {
-    val graphData = new GraphData()
-    
-    for (snapshot <- dataArray) {
-      graphData.addPlotsFromSnapshot(snapshot)
-    }
-      
-    graphData
   }
 }

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -32,7 +32,7 @@ class HomeController @Inject()(val controllerComponents: ControllerComponents, v
    */
   def index() = Action.async { implicit request: Request[AnyContent] =>
     resortData.getLatestSnapshotForAllResorts.map(
-      rvArray => rvArray.map(f => ResortSnapshotFactory.resortSnapshotFromJson(f._1.asInstanceOf[String], ResortsFactory.fromDBString(f._2)))//ResortSnapshotFactory.fromJson(f(0).asInstanceOf[String], ta).asInstanceOf[ResortSnapshot]
+      rvArray => rvArray.map(f => ResortSnapshotFactory.resortSnapshotFromJson(f._1.asInstanceOf[String], ResortsFactory.fromDBString(f._2)))
     ).map(snapshotArray => Ok(views.html.index(snapshotArray, ResortSnapshotFactory.resortsList)))
   }
 
@@ -68,10 +68,10 @@ class HomeController @Inject()(val controllerComponents: ControllerComponents, v
   private def generateGraphData(dataArray: Array[ResortDataSnapshot]): GraphData = {
     val graphData = new GraphData()
     
-    for 
-      snapshot <- dataArray 
-    yield 
+    for (snapshot <- dataArray) {
       graphData.addPlotsFromSnapshot(snapshot)
-      graphData
+    }
+      
+    graphData
   }
 }

--- a/app/models/DataPointTypes.scala
+++ b/app/models/DataPointTypes.scala
@@ -1,3 +1,5 @@
+package models
+
 sealed trait DataPointTypes
 case object DailySnow extends DataPointTypes {
     override def toString: String = "dailySnow"

--- a/app/models/DataPointTypes.scala
+++ b/app/models/DataPointTypes.scala
@@ -1,0 +1,16 @@
+sealed trait DataPointTypes
+case object DailySnow extends DataPointTypes {
+    override def toString: String = "dailySnow"
+}
+case object BaseDepth extends DataPointTypes {
+    override def toString: String = "baseDepth"
+}
+case object Temperature extends DataPointTypes {
+    override def toString: String = "temperature"
+}
+case object WindSpeed extends DataPointTypes {
+    override def toString: String = "windSpeed"
+}
+case object WindDir extends DataPointTypes {
+    override def toString: String = "windDir"
+}

--- a/app/models/DatabaseModel.scala
+++ b/app/models/DatabaseModel.scala
@@ -1,9 +1,6 @@
 package models
 
-import play.api.libs.json.Json
-import play.api.libs.json.Writes
-import play.api.libs.json.JsValue
-import play.api.libs.json.JsString
+import play.api.libs.json._
 
 final case class DatabaseSnapshot(dailySnow: Int, baseDepth: Int, temperature: Int, windSpeed: Int, windDir: CardinalDirections) {
     implicit val dirWrites = new Writes[CardinalDirections] {

--- a/app/models/WebModel.scala
+++ b/app/models/WebModel.scala
@@ -59,9 +59,9 @@ object ResortSnapshotFactory {
 final case class ResortData(dailySnow: Int, baseDepth: Int, temperature: Int, windSpeed: Int, windDir: CardinalDirections) 
 final case class ResortSnapshot(resort: Resorts, resortData: ResortData)
 final case class ResortDataSnapshot(timestamp: String, resortData: ResortData)
-final case class DataPlot(timestamp: String, value: Either[String, Int]) {
+final case class DataPlot(x: String, y: Either[CardinalDirections, Int]) {
   implicit val valWrites = new Writes[Either[CardinalDirections, Int]] {
-    def writes(o: Either[String,Int]): JsValue = o.fold(
+    def writes(o: Either[CardinalDirections, Int]): JsValue = o.fold(
       l => JsString(l.toString()),
       r => JsNumber(r)
     )
@@ -154,18 +154,24 @@ case object WinterPark extends Resorts {
 }
 
 
-class GraphData () {
-	val dailySnow = ArrayBuffer[DataPlot]()
-	val baseDepth = ArrayBuffer[DataPlot]()
-	val temperature = ArrayBuffer[DataPlot]()
-	val windSpeed = ArrayBuffer[DataPlot]()
-	val windDir = ArrayBuffer[DataPlot]()
+class GraphData (dataArray: Array[ResortDataSnapshot]) {
+	private val _dailySnow = ArrayBuffer[DataPlot]()
+	private val _baseDepth = ArrayBuffer[DataPlot]()
+	private val _temperature = ArrayBuffer[DataPlot]()
+	private val _windSpeed = ArrayBuffer[DataPlot]()
+	private val _windDir = ArrayBuffer[DataPlot]()
 
-	def addPlotsFromSnapshot(snapshot: ResortDataSnapshot): Unit = {
-        dailySnow += new DataPlot(snapshot.timestamp, Right(snapshot.resortData.dailySnow))
-        baseDepth += new DataPlot(snapshot.timestamp, Right(snapshot.resortData.baseDepth))
-        temperature += new DataPlot(snapshot.timestamp, Right(snapshot.resortData.temperature))
-        windSpeed += new DataPlot(snapshot.timestamp, Right(snapshot.resortData.windSpeed))
-        windDir += new DataPlot(snapshot.timestamp, Left(snapshot.resortData.windDir))
+	for (snapshot <- dataArray) {
+        _dailySnow += new DataPlot(snapshot.timestamp, Right(snapshot.resortData.dailySnow))
+        _baseDepth += new DataPlot(snapshot.timestamp, Right(snapshot.resortData.baseDepth))
+        _temperature += new DataPlot(snapshot.timestamp, Right(snapshot.resortData.temperature))
+        _windSpeed += new DataPlot(snapshot.timestamp, Right(snapshot.resortData.windSpeed))
+        _windDir += new DataPlot(snapshot.timestamp, Left(snapshot.resortData.windDir))
     }
+
+    val dailySnow = Json.toJson(_dailySnow.map(e => e.toJson()))
+	val baseDepth = Json.toJson(_baseDepth.map(e => e.toJson()))
+	val temperature = Json.toJson(_temperature.map(e => e.toJson()))
+	val windSpeed = Json.toJson(_windSpeed.map(e => e.toJson()))
+	val windDir = Json.toJson(_windDir.map(e => e.toJson()))
 }

--- a/app/models/WebModel.scala
+++ b/app/models/WebModel.scala
@@ -17,29 +17,24 @@ object ResortSnapshotFactory {
         case default => throw new Error("Tried to read string that wasn't a Cardinal Direction: "+ default.as[String])
     }
     implicit val resortDataRead: Reads[ResortData] = (
-        (JsPath \ "dailySnow").read[Int] and
-        (JsPath \ "baseDepth").read[Int] and
-        (JsPath \ "temperature").read[Int] and
-        (JsPath \ "windSpeed").read[Int] and
-        (JsPath \ "windDir").read[CardinalDirections]
+        (JsPath \ DailySnow.toString()).read[Int] and
+        (JsPath \ BaseDepth.toString()).read[Int] and
+        (JsPath \ Temperature.toString()).read[Int] and
+        (JsPath \ WindSpeed.toString()).read[Int] and
+        (JsPath \ WindDir.toString()).read[CardinalDirections]
     ) (ResortData.apply _)
 
-    val resortsList: List[Resorts] = List(
-        ArapahoeBasin,
-        Breckenridge,
-        BeaverCreek,
-        Vail,
-        Keystone,
-        Eldora,
-        Copper,
-        WinterPark
-    )
 
     def resortSnapshotFromJson(data: String, resort:Resorts): ResortSnapshot = {
         val jsonData = Json.parse(data)
         val resortData = Json.fromJson[ResortData](jsonData)
         new ResortSnapshot(resort, resortData.get)
     }
+
+
+
+
+
 
     def resortDataSnapshotFromJson(data: String, timestamp: String): ResortDataSnapshot = {
             val dataOption = Option(data)
@@ -87,6 +82,7 @@ object ResortsFactory {
         }
     }
 }
+
 sealed trait Resorts { val databaseName: String; val scrapeUrl: String }
 sealed trait PowdrResorts extends Resorts { val location_id: Int }
 case object ArapahoeBasin extends Resorts {
@@ -136,3 +132,14 @@ case object WinterPark extends Resorts {
     override val databaseName: String = "WINTERPARK"
     override val scrapeUrl: String = "https://mtnpowder.com/feed?resortId=5"
 }
+
+val ResortsList: List[Resorts] = List(
+    ArapahoeBasin,
+    Breckenridge,
+    BeaverCreek,
+    Vail,
+    Keystone,
+    Eldora,
+    Copper,
+    WinterPark
+)

--- a/app/models/WebModel.scala
+++ b/app/models/WebModel.scala
@@ -59,7 +59,20 @@ object ResortSnapshotFactory {
 final case class ResortData(dailySnow: Int, baseDepth: Int, temperature: Int, windSpeed: Int, windDir: CardinalDirections) 
 final case class ResortSnapshot(resort: Resorts, resortData: ResortData)
 final case class ResortDataSnapshot(timestamp: String, resortData: ResortData)
-final case class DataPlot(y: Any, x: Any)
+final case class DataPlot(timestamp: String, value: Either[String, Int]) {
+  implicit val valWrites = new Writes[Either[CardinalDirections, Int]] {
+    def writes(o: Either[String,Int]): JsValue = o.fold(
+      l => JsString(l.toString()),
+      r => JsNumber(r)
+    )
+  } 
+  implicit val writes = Json.writes[DataPlot]
+
+  def toJson(): String = {
+  	return Json.toJson(this).toString()
+  }
+    
+}
 
 object ResortsFactory {
     def fromDBString(resort: String): Resorts = {
@@ -149,10 +162,10 @@ class GraphData () {
 	val windDir = ArrayBuffer[DataPlot]()
 
 	def addPlotsFromSnapshot(snapshot: ResortDataSnapshot): Unit = {
-        dailySnow += new DataPlot(snapshot.timestamp, snapshot.resortData.dailySnow)
-        baseDepth += new DataPlot(snapshot.timestamp, snapshot.resortData.baseDepth)
-        temperature += new DataPlot(snapshot.timestamp, snapshot.resortData.temperature)
-        windSpeed += new DataPlot(snapshot.timestamp, snapshot.resortData.windSpeed)
-        windDir += new DataPlot(snapshot.timestamp, snapshot.resortData.windDir)
+        dailySnow += new DataPlot(snapshot.timestamp, Right(snapshot.resortData.dailySnow))
+        baseDepth += new DataPlot(snapshot.timestamp, Right(snapshot.resortData.baseDepth))
+        temperature += new DataPlot(snapshot.timestamp, Right(snapshot.resortData.temperature))
+        windSpeed += new DataPlot(snapshot.timestamp, Right(snapshot.resortData.windSpeed))
+        windDir += new DataPlot(snapshot.timestamp, Left(snapshot.resortData.windDir))
     }
 }

--- a/app/models/WebModel.scala
+++ b/app/models/WebModel.scala
@@ -59,7 +59,7 @@ object ResortSnapshotFactory {
 final case class ResortData(dailySnow: Int, baseDepth: Int, temperature: Int, windSpeed: Int, windDir: CardinalDirections) 
 final case class ResortSnapshot(resort: Resorts, resortData: ResortData)
 final case class ResortDataSnapshot(timestamp: String, resortData: ResortData)
-final case class DataPlot(timestamp: String, value: String | Int)
+final case class DataPlot(y: Any, x: Any)
 
 object ResortsFactory {
     def fromDBString(resort: String): Resorts = {

--- a/app/views/resort.scala.html
+++ b/app/views/resort.scala.html
@@ -5,11 +5,7 @@
 
     <h2>Daily Snow</h2>
     <div>
-        [
-            @for(plot <- graphData.dailySnow) {
-                { x: @plot.x, y: @plot.y}
-            }
-        ]
+        @graphData.dailySnow
     </div>
 
 }

--- a/app/views/resort.scala.html
+++ b/app/views/resort.scala.html
@@ -1,4 +1,4 @@
-@(snapshotArray: Array[ResortDataSnapshot], resort: Resorts, resortList: List[Resorts])
+@(graphData: GraphData, resort: Resorts, resortList: List[Resorts])
 
 @main("Ski Resort Dashboard", "stylesheet/resort.css", resortList, resort.toString()) {
     <h1>@resort.toString()</h1>

--- a/app/views/resort.scala.html
+++ b/app/views/resort.scala.html
@@ -3,16 +3,13 @@
 @main("Ski Resort Dashboard", "stylesheet/resort.css", resortList, resort.toString()) {
     <h1>@resort.toString()</h1>
 
-    <ul>
-        @for(snapshot <- snapshotArray) {
-            <li>Time: @snapshot.timestamp
-                24 Hour Snowfall: @snapshot.resortData.dailySnow inches 
-                Current Snow Depth: @snapshot.resortData.baseDepth inches
-                Current Temperature: @snapshot.resortData.temperature farenheit
-                Current Wind Speed: @snapshot.resortData.windSpeed mph
-                Current Wind Direction: @snapshot.resortData.windDir.toString()
-            </li>
-        }
-    </ul>
+    <h2>Daily Snow</h2>
+    <div>
+        [
+            @for(plot <- graphData.dailySnow) {
+                { x: @plot.x, y: @plot.y}
+            }
+        ]
+    </div>
 
 }


### PR DESCRIPTION
This PR updates the way that the individual resort data is presented on the individual resort pages. It encapsulates the data in a class that contains JSON arrays with each data point in an object with X and Y keys to be used in the Lit-Graph component. Changes in this PR include:

- A new model for the different DataPoint types with Scala "Enums" representing each data point type
- Minimizing imports in DatabaseModel
- Using DataPointTypes enum in resortModel read
- Created DataPlot case class with JSON write method
- Created GraphData class for converting and housing JSON arrays of DataPointTypes
- Updates resort.scala.html to display JSON arrays of DataPontTypes from GraphData

Fixes #105