### PR TITLE
[Issue 106] Render Data Into Graphs

### DIFF
--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -14,6 +14,7 @@ import scrapers.ScraperFactory
 import play.api.libs.ws.WSClient
 import scrapers.PowdrScraper
 import scrapers.WinterParkScraper
+import play.api.Configuration
 
 
 /**
@@ -21,8 +22,9 @@ import scrapers.WinterParkScraper
  * application's home page.
  */
 @Singleton
-class HomeController @Inject()(val controllerComponents: ControllerComponents, val resortData: ResortData, val ws: WSClient) extends BaseController {
+class HomeController @Inject()(val controllerComponents: ControllerComponents, val resortData: ResortData, val ws: WSClient, config: Configuration) extends BaseController {
 
+  val cdnURL = config.get[String]("config.cdn.url")
   /**
    * Create an Action to render an HTML page.
    *
@@ -39,7 +41,7 @@ class HomeController @Inject()(val controllerComponents: ControllerComponents, v
   def resort(resort: Resorts) = Action.async { implicit request: Request[AnyContent] => 
     resortData.getAllSnapshotsForSingleResort(resort).map(
       dataArray => dataArray.map(v => ResortSnapshotFactory.resortDataSnapshotFromJson(v._1, v._2.toString()))
-    ).map(dataArray => Ok(views.html.resort(new GraphData(dataArray), resort, ResortSnapshotFactory.resortsList)))
+    ).map(dataArray => Ok(views.html.resort(new GraphData(dataArray), resort, ResortSnapshotFactory.resortsList, cdnURL)))
   }
 
   def scrape() = Action.async { implicit request: Request[AnyContent] => 

--- a/app/models/WebModel.scala
+++ b/app/models/WebModel.scala
@@ -59,20 +59,7 @@ object ResortSnapshotFactory {
 final case class ResortData(dailySnow: Int, baseDepth: Int, temperature: Int, windSpeed: Int, windDir: CardinalDirections) 
 final case class ResortSnapshot(resort: Resorts, resortData: ResortData)
 final case class ResortDataSnapshot(timestamp: String, resortData: ResortData)
-final case class DataPlot(x: String, y: Either[CardinalDirections, Int]) {
-  implicit val valWrites = new Writes[Either[CardinalDirections, Int]] {
-    def writes(o: Either[CardinalDirections, Int]): JsValue = o.fold(
-      l => JsString(l.toString()),
-      r => JsNumber(r)
-    )
-  } 
-  implicit val writes = Json.writes[DataPlot]
 
-  def toJson(): String = {
-  	return Json.toJson(this).toString()
-  }
-    
-}
 
 object ResortsFactory {
     def fromDBString(resort: String): Resorts = {
@@ -155,6 +142,16 @@ case object WinterPark extends Resorts {
 
 
 class GraphData (dataArray: Array[ResortDataSnapshot]) {
+    implicit val valWrites = new Writes[Either[CardinalDirections, Int]] {
+        def writes(o: Either[CardinalDirections, Int]): JsValue = o.fold(
+        l => JsString(l.toString()),
+        r => JsNumber(r)
+        )
+    } 
+    implicit val writes = Json.writes[DataPlot]
+
+    final case class DataPlot(x: String, y: Either[CardinalDirections, Int])
+
 	private val _dailySnow = ArrayBuffer[DataPlot]()
 	private val _baseDepth = ArrayBuffer[DataPlot]()
 	private val _temperature = ArrayBuffer[DataPlot]()
@@ -169,9 +166,9 @@ class GraphData (dataArray: Array[ResortDataSnapshot]) {
         _windDir += new DataPlot(snapshot.timestamp, Left(snapshot.resortData.windDir))
     }
 
-    val dailySnow = Json.toJson(_dailySnow.map(e => e.toJson()))
-	val baseDepth = Json.toJson(_baseDepth.map(e => e.toJson()))
-	val temperature = Json.toJson(_temperature.map(e => e.toJson()))
-	val windSpeed = Json.toJson(_windSpeed.map(e => e.toJson()))
-	val windDir = Json.toJson(_windDir.map(e => e.toJson()))
+    val dailySnow = Json.toJson(_dailySnow)
+	val baseDepth = Json.toJson(_baseDepth)
+	val temperature = Json.toJson(_temperature)
+	val windSpeed = Json.toJson(_windSpeed)
+	val windDir = Json.toJson(_windDir)
 }

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,6 +1,6 @@
 @(snapshotArray: Array[ResortSnapshot], resortList: List[Resorts])
 
-@main("Ski Resort Dashboard","stylesheets/home.css", resortList, "Home") {
+@main("Ski Resort Dashboard - Home","stylesheets/home.css", resortList, "Home", "") {
   <div id="container">
     <h1>Ski Resort Dashboard</h1>
     <p id="description">

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -4,7 +4,7 @@
  * two arguments, a `String` for the title of the page and an `Html`
  * object to insert into the body of the page.
  *@
-@(title: String, styles: String, resortList: List[Resorts], navImgSrc: String)(content: Html)
+@(title: String, styles: String, resortList: List[Resorts], navImgSrc: String, cdnURL: String)(content: Html)
 
 <!DOCTYPE html>
 <html lang="en">
@@ -33,5 +33,8 @@
         @content
 
       <script src="@routes.Assets.at("javascripts/Navbar.js")" type="module"></script>
+      @if(cdnURL.length != 0) {
+        <script src="@cdnURL/lit-graph.min.js" type="module"></script>
+      }
     </body>
 </html>

--- a/app/views/resort.scala.html
+++ b/app/views/resort.scala.html
@@ -1,6 +1,6 @@
-@(graphData: GraphData, resort: Resorts, resortList: List[Resorts])
+@(graphData: GraphData, resort: Resorts, resortList: List[Resorts], cdnURL: String)
 
-@main("Ski Resort Dashboard", "stylesheet/resort.css", resortList, resort.toString()) {
+@main("Ski Resort Dashboard - " + resort.toString(), "stylesheet/resort.css", resortList, resort.toString(), cdnURL: String) {
     <h1>@resort.toString()</h1>
 
     <h2>Daily Snow</h2>

--- a/app/views/resort.scala.html
+++ b/app/views/resort.scala.html
@@ -5,7 +5,6 @@
 
     <h2>Daily Snow</h2>
     <div>
-        @graphData.dailySnow
+        <lit-graph x-label="Dates" y-label="Inches" data="@graphData.dailySnow"></lit-graph>
     </div>
-
 }

--- a/build.sbt
+++ b/build.sbt
@@ -24,3 +24,6 @@ play.sbt.routes.RoutesKeys.routesImport += "util.Binders._"
 // Remove Documenation From Production Build
 Compile / doc / sources := Seq.empty
 Compile / packageDoc / publishArtifact := false
+
+// Dev config
+PlayKeys.devSettings += "config.cdn.url" -> "http://localhost:3000"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -18,5 +18,6 @@ slick.dbs.default {
     maxConnections=2
   }
 }
+config.cdn.url="https://lms-cdn.fly.dev"
 
 


### PR DESCRIPTION
This PR is to get Lit-Graph actually setup and rendering the data from the resorts into the Graph. Their are two major pieces to this PR: getting Lit-Graph pulled correctly onto the page and setting up any infrastructure that goes with that as well as massaging the data so it gets rendered onto the HTML page correctly and in a form that the Lit-Graph component can use.

Changes in this PR include:

- Add the Laughing man studios CDN url to project configuration
- 